### PR TITLE
refactor(sts): drop LT_SENTINEL workaround — no upstream bug exists

### DIFF
--- a/lib/metanorma/oiml/sts/html_renderer/ruby.rb
+++ b/lib/metanorma/oiml/sts/html_renderer/ruby.rb
@@ -114,31 +114,12 @@ module Metanorma
 
           attr_reader :templates_dir, :assets_dir
 
-          # Placeholder used to shield "&lt;" entities from lutaml-model's
-          # mixed_content parser, which drops "&lt;" inside <mo> elements
-          # when parsing a full STS document (small fragments parse
-          # correctly). The Unicode private-use character U+E000 is a
-          # valid XML character that lutaml-model preserves verbatim
-          # through from_xml → to_xml roundtrips, and CGI.escapeHTML
-          # leaves it untouched.
-          LT_SENTINEL = ""
-
+          # Accept either a parsed model or a raw XML string; the
+          # latter is parsed via the sts-ruby typed model.
           def coerce_model(input)
             return input if input.is_a?(Lutaml::Model::Serializable)
 
-            encoded = shield_lt_entities(input.to_s)
-            ::Sts::IsoSts::Standard.from_xml(encoded)
-          end
-
-          # Replace "<mo>&lt;</mo>" with "<mo>{LT_SENTINEL}</mo>" so the
-          # less-than content survives the parse roundtrip; the renderer
-          # restores it via #restore_lt_entities during math emission.
-          def shield_lt_entities(xml)
-            xml.gsub(/(<(?:mml:)?mo>)&lt;(<\/(?:mml:)?mo>)/, "\\1#{LT_SENTINEL}\\2")
-          end
-
-          def restore_lt_entities(html)
-            html.gsub(LT_SENTINEL, "&lt;")
+            ::Sts::IsoSts::Standard.from_xml(input.to_s)
           end
 
           # --------------------------------------------------------------
@@ -160,14 +141,13 @@ module Metanorma
           # element spacing; MN HTML uses bare element names with
           # newlines between them. Strip the prefix and add newlines
           # so Nokogiri's text extraction produces the same whitespace
-          # between MathML leaf elements. The LT_SENTINEL placed by
-          # coerce_model is restored to "&lt;" here.
+          # between MathML leaf elements.
           def mathml_to_html(node)
-            restore_lt_entities(node.to_xml.to_s
+            node.to_xml.to_s
               .gsub(/<(\/?)mml:/, '<\1')
               .gsub(/\s+xmlns:mml="[^"]*"/, "")
               .gsub(/\s+xmlns:xlink="[^"]*"/, "")
-              .gsub(/></, ">\n<"))
+              .gsub(/></, ">\n<")
           end
 
           # --------------------------------------------------------------

--- a/spec/sts/mathml_lt_entity_spec.rb
+++ b/spec/sts/mathml_lt_entity_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "sts"
+require "mml"
+
+# Regression spec: lock in the round-trip behaviour for STS documents
+# that nest MathML inside mixed_content parents (the OIML sts-guidelines
+# shape: a paragraph with an inline-formula whose <mml:math> contains
+# a <mo>&lt;</mo> operator).
+#
+# Background: an earlier workaround (LT_SENTINEL, removed in this PR)
+# shielded "<mo>&lt;</mo>" from what was believed to be a lutaml-model
+# mixed_content parser bug. The mml team verified on mml 2.4.0 +
+# lutaml-model 0.8.17 + nokogiri 1.19.2 that no such bug exists — the
+# round-trip preserves the entity correctly. These specs lock that
+# contract in at the OIML STS layer.
+RSpec.describe "MathML <mo>&lt;</mo> round-trip through Sts::IsoSts::Standard" do
+  let(:document_with_lt) do
+    <<~XML.freeze
+      <?xml version="1.0" encoding="UTF-8"?>
+      <standard xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML">
+        <body>
+          <sec>
+            <p>For values of x where x <inline-formula>
+              <mml:math>
+                <mml:mi>x</mml:mi>
+                <mml:mo>&lt;</mml:mo>
+                <mml:mn>5</mml:mn>
+              </mml:math>
+            </inline-formula> 5, the result holds.</p>
+          </sec>
+        </body>
+      </standard>
+    XML
+  end
+
+  # The mo element may serialise with or without the mml: prefix
+  # depending on namespace registration state — what matters is that
+  # the &lt; entity survives as the element's content.
+  def mo_content(roundtripped)
+    match = roundtripped.match(/<(?:mml:)?mo[^>]*>([^<]*)<\/(?:mml:)?mo>/)
+    match && match[1]
+  end
+
+  it "preserves the &lt; entity as the mo element's content" do
+    parsed = Sts::IsoSts::Standard.from_xml(document_with_lt)
+    roundtripped = parsed.to_xml
+    expect(mo_content(roundtripped)).to eq("&lt;")
+  end
+
+  it "preserves multiple operators in sequence" do
+    doc = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <standard xmlns:mml="http://www.w3.org/1998/Math/MathML">
+        <body><sec><p>
+          <inline-formula><mml:math>
+            <mml:mi>a</mml:mi>
+            <mml:mo>&lt;</mml:mo>
+            <mml:mi>b</mml:mi>
+            <mml:mo>&gt;</mml:mo>
+            <mml:mi>c</mml:mi>
+          </mml:math></inline-formula>
+        </p></sec></body>
+      </standard>
+    XML
+    parsed = Sts::IsoSts::Standard.from_xml(doc)
+    roundtripped = parsed.to_xml
+    # Extract all mo contents
+    contents = roundtripped.scan(/<(?:mml:)?mo[^>]*>([^<]*)<\/(?:mml:)?mo>/).flatten
+    expect(contents).to include("&lt;", "&gt;")
+  end
+
+  it "preserves the lt entity when interleaved with text content" do
+    doc = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <standard xmlns:mml="http://www.w3.org/1998/Math/MathML">
+        <body><sec><p>before <inline-formula>
+          <mml:math><mml:mo>&lt;</mml:mo></mml:math>
+        </inline-formula> after</p></sec></body>
+      </standard>
+    XML
+    parsed = Sts::IsoSts::Standard.from_xml(doc)
+    expect(mo_content(parsed.to_xml)).to eq("&lt;")
+  end
+end


### PR DESCRIPTION
## Summary

- Drops the `LT_SENTINEL` workaround (added in #20) — the mml team verified no upstream bug exists with mml 2.4.0 + lutaml-model 0.8.17 + nokogiri 1.19.2.
- Adds 3 regression specs at the OIML STS layer that lock in the correct `<mo>&lt;</mo>` round-trip behavior.

## Why

The original root-cause analysis in the `LT_SENTINEL` comment claimed lutaml-model's mixed_content parser dropped `&lt;` inside `<mo>` elements. That analysis was wrong:

- `Lutaml::Xml::ModelTransform#value_for_rule` selects matching child elements as adapter `XmlElement` objects, not strings.
- `Lutaml::Model::Attribute#cast` routes `Serializable` types via `klass.apply_mappings(value, :xml, ...)` where `value` is still the adapter element.
- Entity decode / re-encode happens inside the Nokogiri/Ox adapter, never as a raw XML string with entities pre-decoded.

Verified by reproducing the exact claim (`sts-ruby` `Standard.from_xml → to_xml` on a document with `<p>… <inline-formula><mml:math>…<mml:mo>&lt;</mml:mo>…</mml:math></inline-formula> …</p>`): the entity survives in every variant (single `&lt;`, multiple entities, interleaved text, V3 + V4).

## Changes

**Removed** (~26 lines):
- `LT_SENTINEL` constant (U+E000 Unicode private-use char).
- `shield_lt_entities` (pre-parsed input swapping `<mo>&lt;</mo>` → `<mo>{sentinel}</mo>`).
- `restore_lt_entities` (undid the swap during math emission).
- The `restore_lt_entities(...)` wrapper in `mathml_to_html`.
- The `shield_lt_entities(input.to_s)` step in `coerce_model`.

**Added**: `spec/sts/mathml_lt_entity_spec.rb` — 3 specs mirroring the mml team's regression coverage but at the OIML STS layer:
- Single `<mml:mo>&lt;</mml:mo>` round-trips correctly.
- Multiple operators (`&lt;`, `&gt;`) round-trip in sequence.
- The entity survives when interleaved with text content.

The matcher tolerates either `mml:`-prefixed or bare element names since namespace serialization can vary with model registration state.

## Test plan

- [x] `bundle exec rspec spec/sts/` — 46 examples, 0 failures.
- [x] Local end-to-end pipeline produces byte-identical output (113,738 B STS HTML) before and after the change.
- [x] Parity validator still reports PASS at 100% paragraph coverage against local metanorma-document.

Refs: mml team's `spec/mml/nested_in_mixed_content_spec.rb` (mml/mml@a3f2c5e) — 14 specs at the mml layer covering the same contract.
